### PR TITLE
feat: Add animated cinematic detail modal for noodle shops

### DIFF
--- a/app/components/ImageCarousel.tsx
+++ b/app/components/ImageCarousel.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+interface ImageCarouselProps {
+  images: string[];
+}
+
+export default function ImageCarousel({ images }: ImageCarouselProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const goToPrevious = () => {
+    const isFirstImage = currentIndex === 0;
+    const newIndex = isFirstImage ? images.length - 1 : currentIndex - 1;
+    setCurrentIndex(newIndex);
+  };
+
+  const goToNext = () => {
+    const isLastImage = currentIndex === images.length - 1;
+    const newIndex = isLastImage ? 0 : currentIndex + 1;
+    setCurrentIndex(newIndex);
+  };
+
+  if (!images || images.length === 0) {
+    return <div className="carousel-container bg-gray-200 rounded-lg flex items-center justify-center text-gray-500">No images available</div>;
+  }
+
+  return (
+    <div className="carousel-container">
+      <div className="carousel-image-container">
+        <Image
+          src={images[currentIndex]}
+          alt={`Slide ${currentIndex + 1}`}
+          className="carousel-image"
+          fill
+          priority={currentIndex === 0} // Prioritize loading the first image
+        />
+      </div>
+      {images.length > 1 && (
+        <>
+          <button onClick={goToPrevious} className="carousel-button prev">
+            &#10094;
+          </button>
+          <button onClick={goToNext} className="carousel-button next">
+            &#10095;
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect } from "react";
+import ImageCarousel from "./ImageCarousel";
+import { motion } from "framer-motion";
+
+type NoodleStatus = "Halal" | "Non-Halal";
+
+interface NoodleShop {
+  name: string;
+  address: string;
+  status: NoodleStatus;
+  style: string;
+  hours: string;
+  mapLink: string;
+  history: string;
+  gallery: string[];
+}
+
+interface ModalProps {
+  shop: NoodleShop;
+  onClose: () => void;
+}
+
+const backdropVariants = {
+  visible: { opacity: 1 },
+  hidden: { opacity: 0 },
+};
+
+const modalVariants = {
+  hidden: {
+    y: "100vh",
+    opacity: 0,
+  },
+  visible: {
+    y: "0",
+    opacity: 1,
+    transition: {
+      type: "spring",
+      stiffness: 120,
+      damping: 20,
+    },
+  },
+};
+
+
+const placeholderHistory = "This legendary noodle house has been serving the community for over 40 years. Starting from a small cart, it has become a local institution, renowned for its secret family recipe passed down through three generations. The noodles are still handmade daily, ensuring the perfect texture and flavor that regulars have come to love.";
+
+export default function Modal({ shop, onClose }: ModalProps) {
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleEsc);
+    return () => {
+      window.removeEventListener("keydown", handleEsc);
+    };
+  }, [onClose]);
+
+  const statusBadgeClass = shop.status === "Halal" ? "halal-badge" : "non-halal-badge";
+  const hasGallery = shop.gallery && shop.gallery.length > 0;
+  const hasHistory = shop.history && shop.history !== placeholderHistory;
+
+  return (
+    <motion.div
+      className="modal-backdrop"
+      onClick={onClose}
+      variants={backdropVariants}
+      initial="hidden"
+      animate="visible"
+      exit="hidden"
+    >
+      <motion.div
+        className="modal-content"
+        onClick={(e) => e.stopPropagation()}
+        variants={modalVariants}
+      >
+        {hasGallery && (
+          <div className="modal-cinematic-header">
+            <ImageCarousel images={shop.gallery} />
+          </div>
+        )}
+
+        <button
+          onClick={onClose}
+          className={`modal-close-button-cinematic ${!hasGallery ? 'modal-close-button-no-header' : ''}`}
+        >
+          &times;
+        </button>
+
+        <div className="modal-body-cinematic">
+          <div className="flex justify-between items-start mb-2">
+            <h2 className="text-2xl font-bold text-gray-800">{shop.name}</h2>
+            <span className={`text-xs font-semibold px-2 py-1 rounded-full ${statusBadgeClass}`}>{shop.status}</span>
+          </div>
+          <p className="text-amber-600 font-semibold text-sm mb-4">{shop.style}</p>
+
+          {hasHistory && (
+            <>
+              <h3 className="text-xl font-bold mb-2">The Story</h3>
+              <p className="text-gray-700 text-sm leading-relaxed text-justify">{shop.history}</p>
+            </>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,3 +49,126 @@ h1, h2, h3 {
   opacity: 1;
   transform: translateY(0);
 }
+
+/* Modal Styles */
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 50;
+  backdrop-filter: blur(4px);
+}
+
+.modal-content {
+  background-color: #FDFCF8;
+  border-radius: 0.75rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  width: 90%;
+  max-width: 40rem;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-cinematic-header {
+  position: relative;
+  width: 100%;
+  height: 20rem;
+}
+
+.modal-close-button-cinematic {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s, transform 0.2s;
+  z-index: 20;
+}
+
+.modal-close-button-cinematic:hover {
+  background: rgba(0, 0, 0, 0.8);
+  transform: scale(1.1);
+}
+
+.modal-close-button-no-header {
+  color: #6b7280;
+  background: transparent;
+}
+
+.modal-close-button-no-header:hover {
+  color: #1f2937;
+  background: #f3f4f6;
+}
+
+.modal-body-cinematic {
+  padding: 1.5rem 2rem 2rem;
+  overflow-y: auto;
+}
+
+/* Image Carousel Styles */
+.carousel-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #e5e7eb;
+}
+
+.carousel-image-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.carousel-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.carousel-button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.4);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  font-size: 1.5rem;
+  transition: background-color 0.2s;
+  z-index: 10;
+}
+
+.carousel-button:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.carousel-button.prev {
+  left: 1rem;
+}
+
+.carousel-button.next {
+  right: 1rem;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Modal from "./components/Modal";
+import { AnimatePresence } from "framer-motion";
 
 type NoodleStatus = "Halal" | "Non-Halal";
 
@@ -11,47 +13,51 @@ interface NoodleShop {
   style: string;
   hours: string;
   mapLink: string;
+  history: string;
+  gallery: string[];
 }
 
+const placeholderHistory = "This legendary noodle house has been serving the community for over 40 years. Starting from a small cart, it has become a local institution, renowned for its secret family recipe passed down through three generations. The noodles are still handmade daily, ensuring the perfect texture and flavor that regulars have come to love.";
+
 const NOODLE_SHOPS: NoodleShop[] = [
-  { name: "Bakmi Abadi (Angke)", address: "Jl. Tubagus Angke No. 89, Angke, Jakarta Barat", status: "Non-Halal", style: "Mie Karet, Lomie", hours: "Mon-Sun: 09:00 - 22:00", mapLink: "#" },
-  { name: "Bakmi Ace (Pademangan)", address: "Jl. Rajawali Selatan XII No. 24, Gn. Sahari Utara, Sawah Besar, Jakarta Pusat", status: "Non-Halal", style: "Kalimantan Style", hours: "Tue-Sun: 07:00 - 18:30 (Mon Closed)", mapLink: "#" },
-  { name: "Bakmi Acang (Grogol)", address: "Jl. Dr. Susilo 3, Grogol, Jakarta Barat", status: "Halal", style: "Ayam Kampung", hours: "Mon-Sun: 10:00 - 22:00", mapLink: "#" },
-  { name: "Bakmi Acing (Grogol)", address: "Jl. Muwardi 1 No. 17, Grogol, Jakarta Barat", status: "Halal", style: "Ayam Kampung", hours: "Daily (Hours vary)", mapLink: "#" },
-  { name: "Bakmi Agoan (Puri)", address: "Ruko Pasar Puri Indah, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "Mie Alot (Gummy Noodle)", hours: "Mon-Sun: 07:00 - 21:00", mapLink: "#" },
-  { name: "Bakmi Akong (Muara Karang)", address: "Jl. Pluit Karang Indah Timur Blok B8 Timur No. 102, Muara Karang, Jakarta Utara", status: "Non-Halal", style: "Mie Campur", hours: "Mon, Wed-Sun: 06:00 - 15:00 (Tue Closed)", mapLink: "#" },
-  { name: "Bakmi Alim Pejagalan (Muara Karang)", address: "Jl. Pluit Karang Sari XV Blok D7 Timur No. 103, Muara Karang, Jakarta Utara", status: "Halal", style: "Ayam Pangsit", hours: "Mon-Sun: 06:30 - 20:00", mapLink: "#" },
-  { name: "Bakmi Aliang Gg. 14 (Pademangan)", address: "Jl. Pademangan II Gang 14 No. 26, Pademangan Timur, Jakarta Utara", status: "Non-Halal", style: "Traditional Chinese-Indonesian", hours: "Tue-Sun: 06:00 - 17:00 (Mon Closed)", mapLink: "#" },
-  { name: "Bakmi Alip (Sawah Besar)", address: "Jl. Sukarjo Wiryopranoto (Sawah Besar)", status: "Halal", style: "Ayam Kampung & Jamur", hours: "Daily: 06:00 - 15:00", mapLink: "#" },
-  { name: "Bakmi Alok (Green Ville)", address: "Jl. Mangga II B No. 38, Green Ville, Jakarta Barat", status: "Halal", style: "Ayam Kampung", hours: "Tue-Sun: 07:00 - 15:00 (Mon Closed)", mapLink: "#" },
-  { name: "Bakmi Aloi (Green Ville)", address: "Jl. Mangga II Blok B No. 37, Green Ville, Jakarta Barat", status: "Non-Halal", style: "Palembang Style", hours: "Mon-Sun: 06:00 - 21:30", mapLink: "#" },
-  { name: "Bakmi Asoi (Puri)", address: "Pasar Puri Indah, Jl. Puri Indah Raya Blok I No. 43, Puri, Jakarta Barat", status: "Non-Halal", style: "Ayam Kampung & Babi Cincang", hours: "Mon-Sun: 06:00 - 13:00", mapLink: "#" },
-  { name: "Bakmi Asiu (Kelapa Gading)", address: "Jl. Kelapa Kopyor Raya Blok Q1 No. 10, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Mie Karet, 6 Toppings", hours: "Daily: 06:00 - 16:30", mapLink: "#" },
-  { name: "Bakmi Asui (Tanjung Duren)", address: "Jl. Tanjung Duren Utara IIIA No. 337B, Grogol petamburan, Jakarta Barat", status: "Halal", style: "Mie Karet Ayam Kampung", hours: "Tue-Sun: 06:00 - 13:00 (Mon Closed)", mapLink: "#" },
-  { name: "Bakmi Asuk (Sunter)", address: "Jl. Danau Sunter Utara No. 59 Blok R, Sunter Agung, Jakarta Utara", status: "Halal", style: "Mie Karet Ayam Kampung", hours: "Mon-Sun: 07:00 - 18:00", mapLink: "#" },
-  { name: "Bakmi Atek Siantar (Puri)", address: "Jl. Puri Kembangan No. 1, Puri, Jakarta Barat", status: "Non-Halal", style: "Mie Keriting Siantar Style", hours: "Daily: 06:00 - 16:00", mapLink: "#" },
-  { name: "Bakmi Ationg (Sunrise Garden)", address: "Komplek Sunrise Garden, Jl. Surya Asih I No. 10, Kebon Jeruk, Jakarta Barat", status: "Halal", style: "Mie Alot Ayam", hours: "Mon-Sun: 06:00 - 18:00", mapLink: "#" },
-  { name: "Bakmi Baji Pamai (Kelapa Gading)", address: "Jl. Boulevard Raya Blok FV1 No. 29-31, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Makassar Style", hours: "Daily (Hours vary)", mapLink: "#" },
-  { name: "Bakmi Belawan Amin (Jelambar)", address: "Jl. Seni Budaya Raya No. 2, Jelambar, Jakarta Barat", status: "Non-Halal", style: "Medan Style", hours: "Mon-Sun: 06:00 - 19:30", mapLink: "#" },
-  { name: "Bakmi Bulon Singkawang (Jelambar)", address: "Jl. Jelambar Baru Raya No. 33, Jelambar, Jakarta Barat", status: "Non-Halal", style: "Singkawang Style", hours: "Mon-Sun: 07:00 - 17:00", mapLink: "#" },
-  { name: "Bakmi Camat (Tan) (Mangga Besar)", address: "Jl. Mangga Besar IV No. 4E, Mangga Besar, Jakarta Barat", status: "Non-Halal", style: "Traditional Chinese-Indonesian", hours: "Tue-Sun: 06:00 - 14:00 (Mon Closed)", mapLink: "#" },
-  { name: "Bakmi Cong Sim (Mangga Besar)", address: "Jl. Raya Mangga Besar No. 2J, Maphar, Taman Sari, Jakarta Barat", status: "Non-Halal", style: "Medan Style", hours: "Mon-Sun: 10:00 - 23:00", mapLink: "#" },
-  { name: "Bakmi Copin (Kelapa Gading)", address: "Jl. Kelapa Hybrida Blok RA 3 No. 5, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Legendary Pork Noodle", hours: "Daily: 07:00 - 22:00", mapLink: "#" },
-  { name: "Bakmi Dina (Puri)", address: "Pasar Puri Indah, Blok K No. 5B, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "Traditional Market Stall", hours: "Mon-Sun: 05:30 - 13:00", mapLink: "#" },
-  { name: "Bakmi Erni (Kelapa Gading)", address: "Jl. Boulevard Raya Blok FY 1 No. 15, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Traditional Chinese-Indonesian", hours: "Daily (Hours vary)", mapLink: "#" },
-  { name: "Bakmi GM (Gajah Mada)", address: "Jl. Gajah Mada No. 92, Krukut, Taman Sari, Jakarta Barat", status: "Halal", style: "Iconic Jakarta Chain", hours: "Mon-Sun: 09:00 - 21:30", mapLink: "#" },
-  { name: "Bakmi Gang Mangga (Glodok)", address: "Jl. Kemurnian IV Gang Mangga No. 38B, Glodok, Jakarta Barat", status: "Non-Halal", style: "Late-Night Noodle", hours: "Daily: 12:00 PM - 03:00 AM", mapLink: "#" },
-  { name: "Bakmi Kah Seng (Tomang)", address: "Jl. Kemuning No. 16, Tomang, Jakarta Barat", status: "Non-Halal", style: "Mie Karet", hours: "Mon-Sun: 07:00 - 14:00", mapLink: "#" },
-  { name: "Bakmi Karet Krekot (Pasar Baru)", address: "Jl. H. Samanhudi No. 6, Pasar Baru, Sawah Besar, Jakarta Pusat", status: "Halal", style: "Mie Karet", hours: "Mon-Sun: 06:00 - 13:00", mapLink: "#" },
-  { name: "Bakmi Karet Planet (Puri)", address: "Pasar Puri Indah Blok I No. 32, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "Mie Karet", hours: "Mon-Sun: 06:00 - 16:00", mapLink: "#" },
-  { name: "Bakmi Khek 63 (Muara Karang)", address: "Jl. Muara Karang Raya Blok B7 Utara No. 115, Muara Karang, Jakarta Utara", status: "Non-Halal", style: "Hakka Style", hours: "Mon-Sun: 06:00 - 15:00", mapLink: "#" },
-  { name: "Bakmi Kribo (Taman Ratu)", address: "Taman Ratu, Jakarta Barat", status: "Non-Halal", style: "Mee Pok, Special Toppings", hours: "Daily (Hours vary)", mapLink: "#" },
-  { name: "Bakmi Ling-ling (Puri Indah)", address: "Ruko Pasar Puri Indah, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "5-Rasa Topping", hours: "Daily (Hours vary)", mapLink: "#" },
-  { name: "Bakmi Lungkee (Hayam Wuruk)", address: "Jl. Hayam Wuruk No. 68, Maphar, Taman Sari, Jakarta Barat", status: "Non-Halal", style: "Mie Kecil/Lebar", hours: "Mon-Sun: 18:00 - 02:00", mapLink: "#" },
-  { name: "Bakmi Orpa (Kota)", address: "Jl. Malaka II No. 25, Kota, Jakarta Barat", status: "Non-Halal", style: "Eggy Noodle, Tahu Bakso", hours: "Mon-Sun: 06:30 - 14:30", mapLink: "#" },
-  { name: "Bakmi Toko Tiga (Menteng)", address: "Jl. KH Wahid Hasyim No. 63A, Menteng, Jakarta Pusat", status: "Halal", style: "Indonesian-Chinese Cuisine", hours: "Mon-Sun: 09:00 - 21:30", mapLink: "#" },
-  { name: "DEMIE Bakmie (Kemang)", address: "Como Park, Jl. Kemang Timur No. 998, Bangka, Jakarta Selatan", status: "Halal", style: "Modern Noodle Bar", hours: "Sun-Thur: 08:00 - 21:00, Fri-Sat: 08:00 - late", mapLink: "#" },
-  { name: "Mie Encim (Sawah Besar)", address: "Jl. Kartini Raya No. 22A, Sawah Besar, Jakarta Pusat", status: "Non-Halal", style: "Legendary Ayam Kampung", hours: "Tue-Sun: 05:30 - 14:00 (Mon Closed)", mapLink: "#" },
+  { name: "Bakmi Abadi (Angke)", address: "Jl. Tubagus Angke No. 89, Angke, Jakarta Barat", status: "Non-Halal", style: "Mie Karet, Lomie", hours: "Mon-Sun: 09:00 - 22:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Ace (Pademangan)", address: "Jl. Rajawali Selatan XII No. 24, Gn. Sahari Utara, Sawah Besar, Jakarta Pusat", status: "Non-Halal", style: "Kalimantan Style", hours: "Tue-Sun: 07:00 - 18:30 (Mon Closed)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Acang (Grogol)", address: "Jl. Dr. Susilo 3, Grogol, Jakarta Barat", status: "Halal", style: "Ayam Kampung", hours: "Mon-Sun: 10:00 - 22:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Acing (Grogol)", address: "Jl. Muwardi 1 No. 17, Grogol, Jakarta Barat", status: "Halal", style: "Ayam Kampung", hours: "Daily (Hours vary)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Agoan (Puri)", address: "Ruko Pasar Puri Indah, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "Mie Alot (Gummy Noodle)", hours: "Mon-Sun: 07:00 - 21:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Akong (Muara Karang)", address: "Jl. Pluit Karang Indah Timur Blok B8 Timur No. 102, Muara Karang, Jakarta Utara", status: "Non-Halal", style: "Mie Campur", hours: "Mon, Wed-Sun: 06:00 - 15:00 (Tue Closed)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Alim Pejagalan (Muara Karang)", address: "Jl. Pluit Karang Sari XV Blok D7 Timur No. 103, Muara Karang, Jakarta Utara", status: "Halal", style: "Ayam Pangsit", hours: "Mon-Sun: 06:30 - 20:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Aliang Gg. 14 (Pademangan)", address: "Jl. Pademangan II Gang 14 No. 26, Pademangan Timur, Jakarta Utara", status: "Non-Halal", style: "Traditional Chinese-Indonesian", hours: "Tue-Sun: 06:00 - 17:00 (Mon Closed)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Alip (Sawah Besar)", address: "Jl. Sukarjo Wiryopranoto (Sawah Besar)", status: "Halal", style: "Ayam Kampung & Jamur", hours: "Daily: 06:00 - 15:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Alok (Green Ville)", address: "Jl. Mangga II B No. 38, Green Ville, Jakarta Barat", status: "Halal", style: "Ayam Kampung", hours: "Tue-Sun: 07:00 - 15:00 (Mon Closed)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Aloi (Green Ville)", address: "Jl. Mangga II Blok B No. 37, Green Ville, Jakarta Barat", status: "Non-Halal", style: "Palembang Style", hours: "Mon-Sun: 06:00 - 21:30", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Asoi (Puri)", address: "Pasar Puri Indah, Jl. Puri Indah Raya Blok I No. 43, Puri, Jakarta Barat", status: "Non-Halal", style: "Ayam Kampung & Babi Cincang", hours: "Mon-Sun: 06:00 - 13:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Asiu (Kelapa Gading)", address: "Jl. Kelapa Kopyor Raya Blok Q1 No. 10, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Mie Karet, 6 Toppings", hours: "Daily: 06:00 - 16:30", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Asui (Tanjung Duren)", address: "Jl. Tanjung Duren Utara IIIA No. 337B, Grogol petamburan, Jakarta Barat", status: "Halal", style: "Mie Karet Ayam Kampung", hours: "Tue-Sun: 06:00 - 13:00 (Mon Closed)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Asuk (Sunter)", address: "Jl. Danau Sunter Utara No. 59 Blok R, Sunter Agung, Jakarta Utara", status: "Halal", style: "Mie Karet Ayam Kampung", hours: "Mon-Sun: 07:00 - 18:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Atek Siantar (Puri)", address: "Jl. Puri Kembangan No. 1, Puri, Jakarta Barat", status: "Non-Halal", style: "Mie Keriting Siantar Style", hours: "Daily: 06:00 - 16:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Ationg (Sunrise Garden)", address: "Komplek Sunrise Garden, Jl. Surya Asih I No. 10, Kebon Jeruk, Jakarta Barat", status: "Halal", style: "Mie Alot Ayam", hours: "Mon-Sun: 06:00 - 18:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Baji Pamai (Kelapa Gading)", address: "Jl. Boulevard Raya Blok FV1 No. 29-31, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Makassar Style", hours: "Daily (Hours vary)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Belawan Amin (Jelambar)", address: "Jl. Seni Budaya Raya No. 2, Jelambar, Jakarta Barat", status: "Non-Halal", style: "Medan Style", hours: "Mon-Sun: 06:00 - 19:30", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Bulon Singkawang (Jelambar)", address: "Jl. Jelambar Baru Raya No. 33, Jelambar, Jakarta Barat", status: "Non-Halal", style: "Singkawang Style", hours: "Mon-Sun: 07:00 - 17:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Camat (Tan) (Mangga Besar)", address: "Jl. Mangga Besar IV No. 4E, Mangga Besar, Jakarta Barat", status: "Non-Halal", style: "Traditional Chinese-Indonesian", hours: "Tue-Sun: 06:00 - 14:00 (Mon Closed)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Cong Sim (Mangga Besar)", address: "Jl. Raya Mangga Besar No. 2J, Maphar, Taman Sari, Jakarta Barat", status: "Non-Halal", style: "Medan Style", hours: "Mon-Sun: 10:00 - 23:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Copin (Kelapa Gading)", address: "Jl. Kelapa Hybrida Blok RA 3 No. 5, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Legendary Pork Noodle", hours: "Daily: 07:00 - 22:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Dina (Puri)", address: "Pasar Puri Indah, Blok K No. 5B, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "Traditional Market Stall", hours: "Mon-Sun: 05:30 - 13:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Erni (Kelapa Gading)", address: "Jl. Boulevard Raya Blok FY 1 No. 15, Kelapa Gading, Jakarta Utara", status: "Non-Halal", style: "Traditional Chinese-Indonesian", hours: "Daily (Hours vary)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi GM (Gajah Mada)", address: "Jl. Gajah Mada No. 92, Krukut, Taman Sari, Jakarta Barat", status: "Halal", style: "Iconic Jakarta Chain", hours: "Mon-Sun: 09:00 - 21:30", mapLink: "#", history: "Founded in 1959, Bakmi GM is one of Jakarta's most iconic and beloved noodle chains. It started from a humble stall in Gajah Mada and has grown into a household name, famous for its consistent quality and signature Pangsit Goreng (fried wontons). The special recipe has been passed down through generations, making it a nostalgic favorite for many Jakartans.", gallery: ["https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/85353fbe-6343-42e5-8a68-61833a6f059e.jpg", "https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/15d5f20a-42c2-480c-9d1d-1f630592a348.jpg", "https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/11181f0b-1e14-4a84-a178-553585149303.jpg"] },
+  { name: "Bakmi Gang Mangga (Glodok)", address: "Jl. Kemurnian IV Gang Mangga No. 38B, Glodok, Jakarta Barat", status: "Non-Halal", style: "Late-Night Noodle", hours: "Daily: 12:00 PM - 03:00 AM", mapLink: "#", history: "A legendary name in Jakarta's late-night culinary scene, Bakmi Gang Mangga operates out of a small alley in the historic Glodok (Chinatown) area. For decades, it has served its signature bakmi, attracting night owls and culinary adventurers. Its enduring popularity is a testament to its unchanging, classic flavor profile, a true taste of old Jakarta.", gallery: ["https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/48a5a54c-7c0b-4589-8968-3d165e69b821.jpg", "https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/4cf39688-42a3-455b-8664-4416a416b2d1.jpg"] },
+  { name: "Bakmi Kah Seng (Tomang)", address: "Jl. Kemuning No. 16, Tomang, Jakarta Barat", status: "Non-Halal", style: "Mie Karet", hours: "Mon-Sun: 07:00 - 14:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Karet Krekot (Pasar Baru)", address: "Jl. H. Samanhudi No. 6, Pasar Baru, Sawah Besar, Jakarta Pusat", status: "Halal", style: "Mie Karet", hours: "Mon-Sun: 06:00 - 13:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Karet Planet (Puri)", address: "Pasar Puri Indah Blok I No. 32, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "Mie Karet", hours: "Mon-Sun: 06:00 - 16:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Khek 63 (Muara Karang)", address: "Jl. Muara Karang Raya Blok B7 Utara No. 115, Muara Karang, Jakarta Utara", status: "Non-Halal", style: "Hakka Style", hours: "Mon-Sun: 06:00 - 15:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Kribo (Taman Ratu)", address: "Taman Ratu, Jakarta Barat", status: "Non-Halal", style: "Mee Pok, Special Toppings", hours: "Daily (Hours vary)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Ling-ling (Puri Indah)", address: "Ruko Pasar Puri Indah, Jl. Puri Indah Raya, Puri, Jakarta Barat", status: "Non-Halal", style: "5-Rasa Topping", hours: "Daily (Hours vary)", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Lungkee (Hayam Wuruk)", address: "Jl. Hayam Wuruk No. 68, Maphar, Taman Sari, Jakarta Barat", status: "Non-Halal", style: "Mie Kecil/Lebar", hours: "Mon-Sun: 18:00 - 02:00", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "Bakmi Orpa (Kota)", address: "Jl. Malaka II No. 25, Kota, Jakarta Barat", status: "Non-Halal", style: "Eggy Noodle, Tahu Bakso", hours: "Mon-Sun: 06:30 - 14:30", mapLink: "#", history: "Bakmi Orpa is a true hidden gem, cherished by those in the know for its exceptionally springy, egg-rich noodles. The shop has been a fixture in the old city for decades, maintaining a loyal following through its commitment to quality and tradition. The addition of their signature 'Tahu Bakso Goreng' (fried tofu meatball) makes for an unforgettable meal.", gallery: ["https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/8e0b6235-9831-411a-9745-13f5920ab03b.jpg"] },
+  { name: "Bakmi Toko Tiga (Menteng)", address: "Jl. KH Wahid Hasyim No. 63A, Menteng, Jakarta Pusat", status: "Halal", style: "Indonesian-Chinese Cuisine", hours: "Mon-Sun: 09:00 - 21:30", mapLink: "#", history: placeholderHistory, gallery: [] },
+  { name: "DEMIE Bakmie (Kemang)", address: "Como Park, Jl. Kemang Timur No. 998, Bangka, Jakarta Selatan", status: "Halal", style: "Modern Noodle Bar", hours: "Sun-Thur: 08:00 - 21:00, Fri-Sat: 08:00 - late", mapLink: "#", history: "A relative newcomer, DEMIE has quickly made a name for itself by reimagining the classic bakmi for a modern palate. Located in the trendy Kemang area, it offers a chic, minimalist take on the noodle bar experience. Their focus on premium ingredients and innovative flavor combinations has attracted a new generation of bakmi enthusiasts.", gallery: ["https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/e6f2129e-63f2-45e6-9e12-24bf53b9f36f.jpg", "https://storage.googleapis.com/gemini-prod-us-west1-d85c5339f40c/images/303530e3-2e38-4e8c-a55e-2e4a428e2365.jpg"] },
+  { name: "Mie Encim (Sawah Besar)", address: "Jl. Kartini Raya No. 22A, Sawah Besar, Jakarta Pusat", status: "Non-Halal", style: "Legendary Ayam Kampung", hours: "Tue-Sun: 05:30 - 14:00 (Mon Closed)", mapLink: "#", history: placeholderHistory, gallery: [] },
 ];
 
 function getAreaFromName(name: string): string {
@@ -59,7 +65,7 @@ function getAreaFromName(name: string): string {
   return match ? match[1].toLowerCase() : "";
 }
 
-function NoodleCard({ shop }: { shop: NoodleShop }) {
+function NoodleCard({ shop, onClick }: { shop: NoodleShop; onClick: () => void }) {
   const [enterActive, setEnterActive] = useState(false);
 
   useEffect(() => {
@@ -76,6 +82,7 @@ function NoodleCard({ shop }: { shop: NoodleShop }) {
       data-area={getAreaFromName(shop.name)}
       data-style={shop.style.toLowerCase()}
       data-status={shop.status}
+      onClick={onClick}
     >
       <div className="p-6">
         <div className="flex justify-between items-start mb-2">
@@ -92,14 +99,11 @@ function NoodleCard({ shop }: { shop: NoodleShop }) {
           </p>
         </div>
         <div className="mt-4">
-          <a
-            href={shop.mapLink}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
             className="inline-block w-full text-center bg-gray-800 text-white font-semibold py-2 px-4 rounded-lg hover:bg-gray-700 transition-colors duration-300"
           >
-            View on Google Maps
-          </a>
+            View Details
+          </button>
         </div>
       </div>
     </div>
@@ -109,6 +113,15 @@ function NoodleCard({ shop }: { shop: NoodleShop }) {
 export default function Home() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | NoodleStatus>("all");
+  const [selectedShop, setSelectedShop] = useState<NoodleShop | null>(null);
+
+  const handleOpenModal = (shop: NoodleShop) => {
+    setSelectedShop(shop);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedShop(null);
+  };
 
   const filteredShops = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
@@ -257,7 +270,7 @@ export default function Home() {
           {/* Noodle Shop List */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {filteredShops.map((shop) => (
-              <NoodleCard key={shop.name} shop={shop} />
+              <NoodleCard key={shop.name} shop={shop} onClick={() => handleOpenModal(shop)} />
             ))}
           </div>
           <p className={`text-center text-gray-500 mt-8 ${filteredShops.length === 0 ? "" : "hidden"}`}>
@@ -265,6 +278,11 @@ export default function Home() {
           </p>
         </section>
       </main>
+
+      {/* Modal */}
+      <AnimatePresence>
+        {selectedShop && <Modal shop={selectedShop} onClose={handleCloseModal} />}
+      </AnimatePresence>
 
       {/* Footer */}
       <footer className="bg-gray-800 text-white py-8">

--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+
+> bakmidex@0.1.0 dev /app
+> next dev --turbopack

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "storage.googleapis.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "framer-motion": "^12.23.22",
+    "next": "15.5.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.3"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      framer-motion:
+        specifier: ^12.23.22
+        version: 12.23.22(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next:
         specifier: 15.5.3
         version: 15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1009,6 +1012,20 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  framer-motion@12.23.22:
+    resolution: {integrity: sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1374,6 +1391,12 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  motion-dom@12.23.21:
+    resolution: {integrity: sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2853,6 +2876,15 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  framer-motion@12.23.22(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.23.21
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -3203,6 +3235,12 @@ snapshots:
       minipass: 7.1.2
 
   mkdirp@3.0.1: {}
+
+  motion-dom@12.23.21:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
This commit introduces a detail modal for each noodle shop card, enhancing the user experience with a cinematic header, smooth animations, and detailed information.

- Adds `framer-motion` for fluid open/close animations.
- Creates `Modal` and `ImageCarousel` components with a new cinematic layout.
- The `ImageCarousel` is now a header for the modal content.
- The `Modal` component conditionally renders the gallery and history sections based on data availability, ensuring a clean UI.
- Updates `page.tsx` to use `AnimatePresence` for handling modal exit animations.
- Adds and refines styles in `globals.css` to support the new layout.
- Uses `next/image` for optimized image loading and configures `next.config.ts`.